### PR TITLE
Android - added getter and publicized X11 DeviceId integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `RedrawEventsCleared` is issued after each set of `RedrawRequested` events.
 - On Android, minimal platform support.
 - Implement synthetic window focus key events on Windows.
+- Added getter for integer value for DeviceId on X11
 
 # 0.20.0 Alpha 5 (2019-12-09)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -242,6 +242,17 @@ pub enum WindowEvent {
 pub struct DeviceId(pub(crate) platform_impl::DeviceId);
 
 impl DeviceId {
+    /// Returns the integer value of the DeviceId. This returns useful values for X11 DeviceIds and 0 for others.
+    pub fn get_index(self) -> i32 {
+        match self {
+            DeviceId(platform_id) => match platform_id {
+                crate::platform::unix::DeviceId::X(i) => match i {
+                    crate::platform::unix::x11::DeviceId(idx) => idx,
+                }
+                _ => 0,
+            }            
+        }
+    }
     /// Returns a dummy `DeviceId`, useful for unit testing. The only guarantee made about the return
     /// value of this function is that it will always be equal to itself and to future values returned
     /// by this function.  No other guarantees are made. This may be equal to a real `DeviceId`.

--- a/src/event.rs
+++ b/src/event.rs
@@ -243,7 +243,7 @@ pub struct DeviceId(pub(crate) platform_impl::DeviceId);
 
 impl DeviceId {
     /// Returns the integer value of the DeviceId. This returns useful values for X11 DeviceIds and 0 for others.
-    pub fn get_index(self) -> i32 {
+    pub fn id(&self) -> u32 {
         match self {
             DeviceId(platform_id) => match platform_id {
                 crate::platform::unix::DeviceId::X(i) => match i {

--- a/src/event.rs
+++ b/src/event.rs
@@ -246,7 +246,7 @@ impl DeviceId {
     pub fn id(&self) -> u32 {
         match self {
             DeviceId(platform_id) => match platform_id {
-                crate::platform::unix::DeviceId::X(i) => match i {
+                platform_id.id()
                     crate::platform::unix::x11::DeviceId(idx) => idx,
                 }
                 _ => 0,

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -23,6 +23,8 @@ pub use crate::platform_impl::x11;
 
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
 
+pub use crate::platform_impl::DeviceId;
+
 /// Theme for wayland client side decorations
 ///
 /// Colors must be in ARGB8888 format

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -514,6 +514,10 @@ impl WindowId {
 pub struct DeviceId(c_int);
 
 impl DeviceId {
+    pub fn id(&self) -> u32 {
+        self.0 as _
+    }
+
     pub unsafe fn dummy() -> Self {
         DeviceId(0)
     }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -511,7 +511,7 @@ impl WindowId {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(c_int);
+pub struct DeviceId(pub c_int);
 
 impl DeviceId {
     pub unsafe fn dummy() -> Self {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -511,7 +511,7 @@ impl WindowId {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(pub c_int);
+pub struct DeviceId(c_int);
 
 impl DeviceId {
     pub unsafe fn dummy() -> Self {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality

The example program is the flutter-rs example.
